### PR TITLE
Fix hardcoded lessons.txt path in update route

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,6 +36,7 @@ if not app.debug:  # Only log to file in production
 # Database configuration
 DATABASE = os.environ.get('CITIZENDEVS_DB_PATH', './citizendevs.db')
 DATAJOBS_DATABASE = os.environ.get('DATAJOBS_DB_PATH', './datajobs.db')
+LESSONS_FILE = os.environ.get('LESSONS_FILE_PATH', './lessons.txt')
 
 def get_db(db_name=None):
     """Open a new database connection if there is none yet for the current application context."""
@@ -581,9 +582,7 @@ def update(username):
 
         return redirect(url_for("dashboard"))
     else:
-        #fn = "/home/engramar/thepusoproject/lessons.txt"
-        fn = "./lessons.txt"
-        with open(fn) as fh:
+        with open(LESSONS_FILE) as fh:
             lessons = [line.rstrip() for line in fh.readlines()]
 
         db = get_db()


### PR DESCRIPTION
- Add configurable LESSONS_FILE environment variable
- Replace hardcoded relative path with environment variable
- Fixes 500 errors when updating user records in production
- Production can set LESSONS_FILE_PATH=/home/engramar/thepusoproject/lessons.txt

🤖 Generated with [Claude Code](https://claude.ai/code)

## Rationale

What does this pull request do?

## Advice for Reviewers & Testing Notes

- Explain how your change should be reviewed, and where reviewers should direct their attention.
- Explain (where relevant) how your change can be tested.

## Screenshots:

- Add a screenshot or two of your changes, where applicable.

## Issue Resolved

*Note - This allows the issue to be automatically linked to the PR once the PR is submitted for review*
- Fixes #<Issue Number>